### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ Web service for geomagnetism data stored in the EDGE.
 (via the waveserver GETSCNLRAW interface)
 
 # Getting started
-- Make sure `node`, `npm`, and `grunt` are installed.
+- Make sure `node`, `npm`, and `grunt-cli` are installed.
 - Make sure the project has been configured using pre-install, use the default values:
 ```
 cd geomag-edge-ws
 src/lib/pre-install
+npm install
 ```
 - Use grunt to start a local development server:
 ```

--- a/src/htdocs/_config.inc.php
+++ b/src/htdocs/_config.inc.php
@@ -21,20 +21,4 @@ $SITE_SITENAV =
 
 $HEAD = $THEME_CSS .
     // page head content
-    ($HEAD ? $HEAD : '') .
-
-    // description meta
-    '<meta name="description" content="' .
-        'USGS Earthquake Hazards Program, responsible for' .
-        ' monitoring, reporting, and researching earthquakes and' .
-        ' earthquake hazards' .
-    '"/>' .
-
-    // keywords meta
-    '<meta name="keywords" content="' .
-        'aftershock,earthquake,epicenter,fault,foreshock,geologist,' .
-        'geophysics,hazard,hypocenter,intensity,intensity scale,magnitude,' .
-        'magnitude scale,mercalli,plate,richter,seismic,seismicity,seismogram,' .
-        'seismograph,seismologist,seismology,subduction,tectonics,tsunami,quake,' .
-        'sismologico,sismologia' .
-    '"/>';
+    ($HEAD ? $HEAD : '');

--- a/src/lib/pre-install.php
+++ b/src/lib/pre-install.php
@@ -31,7 +31,7 @@ if (!is_dir($CONF_DIR)) {
 
 // configuration defaults
 $DEFAULTS = array(
-  'MOUNT_PATH' => '/ws/geomag',
+  'MOUNT_PATH' => '/ws/edge',
   'EDGE_WS_VERSION' => '0.1.0',
   'EDGE_HOST' => 'cwbpub.cr.usgs.gov',
   'EDGE_PORT' => '2060',


### PR DESCRIPTION
Fixes #1.

Add `npm install` and `grunt-cli` to getting started section of readme.
Update default url set by pre-install to match readme example link.