### PR TITLE
Refactor service and improve date/time handling

### DIFF
--- a/src/lib/classes/GeomagWebService.class.php
+++ b/src/lib/classes/GeomagWebService.class.php
@@ -1,34 +1,14 @@
 <?php
 
+include_once $LIB_DIR . '/classes/WebService.class.php';
 include_once $LIB_DIR . '/classes/GeomagQuery.class.php';
 include_once $LIB_DIR . '/classes/Iaga2002OutputFormat.class.php';
 include_once $LIB_DIR . '/classes/JsonOutputFormat.class.php';
 
 
-class GeomagWebService {
+class GeomagWebService extends WebService {
 
   const VERSION = '0.1.3';
-  const ISO8601 = 'Y-m-d\TH:i:s\Z';
-
-  const NO_DATA = 204;
-  const BAD_REQUEST = 400;
-  const NOT_FOUND = 404;
-  const CONFLICT = 409;
-  const SERVER_ERROR = 500;
-  const NOT_IMPLEMENTED = 501;
-  const SERVICE_UNAVAILABLE = 503;
-
-  // status message text
-  public static $statusMessage = array(
-    self::NO_DATA => 'No Data',
-    self::BAD_REQUEST => 'Bad Request',
-    self::NOT_FOUND => 'Not Found',
-    self::CONFLICT => 'Conflict',
-    self::SERVER_ERROR => 'Internal Server Error',
-    self::NOT_IMPLEMENTED => 'Not Implemented',
-    self::SERVICE_UNAVAILABLE => 'Service Unavailable'
-  );
-
 
   public $waveserver;
   public $metadata;
@@ -42,6 +22,7 @@ class GeomagWebService {
    *        Associative array of metadata, keyed by upper case observatory id.
    */
   public function __construct($waveserver, $metadata) {
+    parent::__construct(self::VERSION);
     $this->waveserver = $waveserver;
     $this->metadata = $metadata;
   }
@@ -211,75 +192,6 @@ class GeomagWebService {
     );
   }
 
-
-  public function error($code, $message) {
-    global $APP_DIR;
-    // only cache errors for 60 seconds
-    $CACHE_MAXAGE = 60;
-    include $APP_DIR . '/lib/cache.inc.php';
-    if (isset($_GET['format']) && $_GET['format'] === 'json') {
-      // For json requests, user wants json output
-      $this->jsonError($code, $message);
-    } else {
-      $this->httpError($code, $message);
-    }
-  }
-
-  public function jsonError ($code, $message) {
-    global $HOST_URL_PREFIX;
-    header('Content-type: application/json');
-    // Does this need to look fully like GeoJSON format?
-    $response = array(
-      'type' => 'Error',
-      'metadata' => array(
-        'status' => $code,
-        'generated' => gmdate(self::ISO8601),
-        'url' => $HOST_URL_PREFIX . $_SERVER['REQUEST_URI'],
-        'title' => self::$statusMessage[$code],
-        'api' => self::VERSION,
-        'error' => $message
-      )
-    );
-    echo str_replace('\/', '/', JsonOutputFormat::safe_json_encode($response));
-    exit();
-  }
-
-  public function httpError ($code, $message) {
-    if (isset(self::$statusMessage[$code])) {
-      $codeMessage = ' ' . self::$statusMessage[$code];
-    } else {
-      $codeMessage = '';
-    }
-    header('HTTP/1.0 ' . $code . $codeMessage);
-    if ($code < 400) {
-      exit();
-    }
-    global $HOST_URL_PREFIX;
-    global $MOUNT_PATH;
-
-    // error message for 400 or 500
-    header('Content-type: text/plain');
-    echo implode("\n", array(
-      'Error ' . $code . ': ' . self::$statusMessage[$code],
-      '',
-      $message,
-      '',
-      'Usage details are available from ' .
-          $HOST_URL_PREFIX . $MOUNT_PATH . '/',
-      '',
-      'Request:',
-      $_SERVER['REQUEST_URI'],
-      '',
-      'Request Submitted:',
-      gmdate(self::ISO8601),
-      '',
-      'Service version:',
-      self::VERSION
-    ));
-    exit();
-  }
-
-
   protected function parseQuery($params) {
     $query = new GeomagQuery();
 
@@ -344,125 +256,6 @@ class GeomagWebService {
     }
 
     return $query;
-  }
-
-
-  /**
-   * Validate a time parameter.
-   *
-   * @param $param parameter name, for error message.
-   * @param $value parameter value
-   * @return value as epoch millisecond timestamp, exit with error if invalid.
-   */
-  protected function validateTime($param, $value) {
-    $parsed = strtotime($value);
-    if ($parsed === false) {
-      $this->error(self::BAD_REQUEST,
-        'Bad ' . $param . ' value "' . $value . '".' .
-        ' Valid values are ISO-8601 timestamps.');
-    }
-    return $parsed;
-  }
-
-  /**
-   * Validate a boolean parameter.
-   *
-   * @param $param parameter name, for error message
-   * @param $value parameter value
-   * @return value as boolean if valid ("true" or "false", case insensitively), exit with error if invalid.
-   */
-  protected function validateBoolean($param, $value) {
-    $val = strtolower($value);
-    if ($val !== 'true' && $val !== 'false') {
-      $this->error(self::BAD_REQUEST,
-          'Bad ' . $param . ' value "' . $value . '".' .
-          ' Valid values are (case insensitive): "TRUE", "FALSE".');
-    }
-    return ($val === 'true');
-  }
-
-  /**
-   * Validate an integer parameter.
-   *
-   * @param $param parameter name, for error message
-   * @param $value parameter value
-   * @param $min minimum valid value for parameter, or null if no minimum.
-   * @param $max maximum valid value for parameter, or null if no maximum.
-   * @return value as integer if valid (integer and in range), exit with error if invalid.
-   */
-  protected function validateInteger($param, $value, $min, $max) {
-    if (
-        !ctype_digit($value)
-        || ($min !== null && intval($value) < $min)
-        || ($max !== null && intval($value) > $max)
-    ) {
-      $message = '';
-      if ($min === null && $max === null) {
-        $message = 'integers';
-      } else {
-        $message = '';
-        if ($min !== null) {
-          $message .= $min . ' <= ';
-        }
-        $message .= $param;
-        if ($max !== null) {
-          $message .= ' <= ' . $max;
-        }
-      }
-      $this->error(self::BAD_REQUEST, 'Bad ' . $param . ' value "' . $value . '".' .
-          ' Valid values are ' . $message);
-    }
-    return intval($value);
-  }
-
-  /**
-   * Validate a float parameter.
-   *
-   * @param $param parameter name, for error message
-   * @param $value parameter value
-   * @param $min minimum valid value for parameter, or null if no minimum.
-   * @param $max maximum valid value for parameter, or null if no maximum.
-   * @return value as float if valid (float and in range), exit with error if invalid.
-   */
-  protected function validateFloat($param, $value, $min, $max) {
-    if (
-        !is_numeric($value)
-        || ($min !== null && floatval($value) < $min)
-        || ($max !== null && floatval($value) > $max)
-    ) {
-      if ($min === null && $max === null) {
-        $message = 'numeric';
-      } else {
-        $message = '';
-        if ($min !== null) {
-          $message .= $min . ' <= ';
-        }
-        $message .= $param;
-        if ($max !== null) {
-          $message .= ' <= ' . $max;
-        }
-      }
-
-      $this->error(self::BAD_REQUEST, 'Bad ' . $param . ' value "' . $value . '".' .
-          ' Valid values are ' . $mesasge);
-    }
-    return floatval($value);
-  }
-
-  /**
-   * Validate a parameter that has an enumerated list of valid values.
-   *
-   * @param $param parameter name, for error message
-   * @param $value parameter value
-   * @param $enum array of valid parameter values.
-   * @return value if valid (in array), exit with error if invalid.
-   */
-  protected function validateEnumerated($param, $value, $enum) {
-    if (!in_array($value, $enum)) {
-      $this->error(self::BAD_REQUEST, 'Bad ' . $param . ' value "' . $value . '".' .
-        ' Valid values are: "' . implode('", "', $enum) . '".');
-    }
-    return $value;
   }
 
 }

--- a/src/lib/classes/Iaga2002OutputFormat.class.php
+++ b/src/lib/classes/Iaga2002OutputFormat.class.php
@@ -6,9 +6,6 @@ class Iaga2002OutputFormat {
   static $EMPTY_VALUE = '99999.99';
 
 
-  public function __construct() {
-  }
-
   public function output($data, $query, $metadata) {
     header('Content-Type: text/plain');
 
@@ -159,7 +156,7 @@ class Iaga2002OutputFormat {
    */
   protected function formatValues($time, $values) {
     $doy = gmdate('z', $time) + 1;
-    return gmdate('Y-m-d H:i:s.000', $time) .
+    return WebService::formatISO8601($time, ' ', '') .
         ' ' . str_pad($doy, 3, '0', STR_PAD_LEFT) .
         '   ' .
         str_pad($values[0], 10, ' ', STR_PAD_LEFT) .

--- a/src/lib/classes/JsonOutputFormat.class.php
+++ b/src/lib/classes/JsonOutputFormat.class.php
@@ -4,6 +4,7 @@ class JsonOutputFormat {
 
   const ISO8601 = 'Y-m-d\TH:i:s\Z';
 
+
   public function output($data, $query, $metadata) {
     global $HOST_URL_PREFIX;
 
@@ -33,7 +34,7 @@ class JsonOutputFormat {
     $times = $data['times'];
     // convert to iso8601
     $times = array_map(function ($t) {
-      return gmdate(self::ISO8601, $t);
+      return WebService::formatISO8601($t);
     }, $times);
 
     // data arrays

--- a/src/lib/classes/Timeseries.class.php
+++ b/src/lib/classes/Timeseries.class.php
@@ -1,0 +1,267 @@
+<?php
+
+
+/**
+ * Utility class for timeseries data.
+ *
+ * When $data or $times are null, empty arrays are used.
+ *
+ * @param $data {Array}
+ *     default null.
+ * @param $times {Array}
+ *     default null.
+ * @throws {Exception} if $data and $times are not the same length.
+ */
+class Timeseries {
+
+  public $data;
+  public $times;
+
+  public function __construct ($data=null, $times=null) {
+    if ($data == null) {
+      $data = array();
+    }
+    if ($times == null) {
+      $times = array();
+    }
+
+    if (count($data) != count($times)) {
+      throw new Exception('data and time array lengths differ');
+    }
+
+    $this->data = $data;
+    $this->times = $times;
+  }
+
+
+  /**
+   * Concatenate two Timeseries and return a new object.
+   *
+   * @param $that {Timeseries}
+   *     timeseries to append.
+   */
+  public function concat ($that) {
+    return new Timeseries(
+        array_merge($this->data, $that->data),
+        array_merge($this->times, $that->times));
+  }
+
+  /**
+   * Find the smallest distance between samples.
+   *
+   * @return {Number}
+   *     minimum difference between time samples,
+   *     or null if timeseries is empty.
+   */
+  public function estimateDelta () {
+    $estimatedDelta = null;
+    $lastTime = null;
+
+    $len = count($this->data);
+    for ($i = 0; $i < $len; $i++) {
+      $time = $this->times[$i];
+
+      if ($lastTime != null) {
+        $delta = $time - $lastTime;
+        if ($estimatedDelta == null || $delta < $estimatedDelta) {
+          $estimatedDelta = $delta;
+        }
+      }
+
+      $lastTime = $time;
+    }
+
+    return $estimatedDelta;
+  }
+
+  /**
+   * Extend or trim timeseries to specified interval.
+   *
+   * @param $startTime {Number}
+   *     float epoch timestamp.
+   * @param $endTime {Number}
+   *     float epoch timestamp.
+   * @param $delta {Number}
+   *     default null.
+   *     when null, $delta is estimated using estimateDelta().
+   *     NOTE: this method does not resample data.
+   * @return {Timeseries}
+   *     new Timeseries object set to start/end extent.
+   * @see fillGaps().
+   */
+  public function extend ($startTime, $endTime, $delta = null) {
+    $size = count($this->times);
+    $timeseries = new Timeseries();
+
+    if ($size == 0) {
+      throw new Exception('cannot extend empty timeseries' .
+          ', use Timeseries::generateEmpty');
+    }
+
+    $delta = ($delta == null ? $this->estimateDelta() : $delta);
+    $i = 0;
+    $time = $this->times[0];
+
+    // ignore data before start
+    while ($time < $startTime) {
+      $i = $i + 1;
+      $time = $this->times[$i];
+    }
+
+    // leading gap, will be filled by fillGaps
+    if (($time - $startTime) >= $delta) {
+      // set empty value in sync with remaining timeseries
+      // fillGaps handles the rest
+      $startTime = $time - (intval(($time - $startTime) / $delta) * $delta);
+      $timeseries->times[] = $startTime;
+      $timeseries->data[] = null;
+    }
+
+    // copy data in range
+    while ($i < $size && $time < $endTime) {
+      $time = $this->times[$i];
+      $timeseries->data[] = $this->data[$i];
+      $timeseries->times[] = $time;
+      $i = $i + 1;
+    }
+
+    // trailing gap, will be filled by fillGaps
+    if (($endTime - $time) >= $delta) {
+      $endTime = $time + (intval(($endTime - $time) / $delta) * $delta);
+      $timeseries->times[] = $endTime;
+      $timeseries->data[] = null;
+    }
+
+    return $timeseries->fillGaps(null, $delta);
+  }
+
+  /**
+   * Fill empty values.
+   *
+   * @param $emptyValue {Number}
+   *     default null.
+   * @return {Timeseries}
+   *     new Timeseries object with gaps filled.
+   */
+  public function fillGaps ($emptyValue = null, $delta = null) {
+    $size = count($this->times);
+    $timeseries = new Timeseries();
+
+    if ($size == 0) {
+      return $timeseries;
+    }
+
+    $delta = ($delta == null ? $this->estimateDelta() : $delta);
+    $endTime = $this->times[$size - 1];
+    $gaps = $this->getTimeGaps($delta);
+    $startTime = $this->times[0];
+
+    $i = 0;
+    $time = $startTime;
+    foreach ($gaps as $gap) {
+      // time of first missing sample
+      $gapStart = $gap[0] + $delta;
+      // time of next sample
+      $gapEnd = $gap[1];
+
+      // copy actual data before gap
+      while ($i < $size && $this->times[$i] < $gapStart) {
+        $time = $this->times[$i];
+        $timeseries->data[] = $this->data[$i];
+        $timeseries->times[] = $time;
+        $i = $i + 1;
+      }
+
+      if ($gapEnd < $gapStart) {
+        // doesn't seem like much of a gap
+        continue;
+      }
+
+      // fill gap with empty value
+      $g = 0;
+      while ($time < $gapEnd) {
+        $time = $gapStart + ($g * $delta);
+        $timeseries->data[] = $emptyValue;
+        $timeseries->times[] = $time;
+        $g = $g + 1;
+      }
+    }
+
+    // copy remaining actual data
+    while ($i < $size) {
+      $time = $this->times[$i];
+      $timeseries->data[] = $this->data[$i];
+      $timeseries->times[] = $time;
+      $i = $i + 1;
+    }
+
+    return $timeseries;
+  }
+
+  /**
+   * Assumes timeseries uses a regular sampling interval.
+   *
+   * @return {Array<gaps>}
+   */
+  public function getTimeGaps ($expectedDelta) {
+    $gaps = array();
+    $lastTime = null;
+
+    $len = count($this->data);
+    for ($i = 0; $i < $len; $i++) {
+      $time = $this->times[$i];
+
+      if ($lastTime != null) {
+        if (($time - $lastTime) != $expectedDelta) {
+          // a gap
+          $gaps[] = array($lastTime, $time);
+        }
+      }
+
+      $lastTime = $time;
+    }
+
+    return $gaps;
+  }
+
+  /**
+   * Check if timeseries is empty.
+   *
+   * @return {Boolean}
+   *     true if empty,
+   *     false otherwise.
+   */
+  public function isEmpty () {
+    return count($this->times) == 0;
+  }
+
+  /**
+   * Generate an empty timeseries.
+   *
+   * A sample will only be generated for endtime
+   * if endtime is an even multiple of delta from starttime.
+   *
+   * @param $startTime {Number}
+   *     float epoch seconds timestamp.
+   * @param $endTime {Number}
+   *     float epoch seconds timestamp.
+   * @param $delta {Number}
+   *     float interval between samples.
+   */
+  public static function generateEmpty ($startTime, $endTime, $delta) {
+    $data = array();
+    $times = array();
+
+    $count = intval($endTime - $startTime) / $delta + 1;
+    for ($i = 0; $i < $count; $i++) {
+      $data[] = null;
+      $times[] = $startTime + ($i * $delta);
+    }
+
+    return new Timeseries($data, $times);
+  }
+
+}
+
+
+?>

--- a/src/lib/classes/TraceBuf.class.php
+++ b/src/lib/classes/TraceBuf.class.php
@@ -1,5 +1,8 @@
 <?php
 
+include_once $LIB_DIR . '/classes/Timeseries.class.php';
+
+
 /**
  * Parser for TraceBuf part of a waveserver response.
  */
@@ -47,6 +50,41 @@ class TraceBuf {
     $this->quality = $header[11];
     $this->pad = $header[12];
     $this->data = $buffer->unpack($this->numSamples . 'i');
+  }
+
+
+  /**
+   * Generate parallel arrays of data and times.
+   *
+   * @return {Array<'data','times' => Array>}
+   */
+  public function toTimeseries () {
+    $data = array();
+    $times = array();
+
+    $len = count($this->data);
+    for ($i = 0; $i < $len; $i++) {
+      $data[] = $this->data[$i];
+      $times[] = $this->startTime + ($i * $this->delta);
+    }
+
+    return new Timeseries($data, $times);
+  }
+
+  /**
+   * Summarize tracebuf.
+   *
+   * @return {String}
+   *     string including tracebuf metadata.
+   */
+  public function toString () {
+    return implode(', ', array(
+      'numSamples=' . $this->numSamples,
+      'startTime=' . $this->startTime,
+      'endTime=' . $this->endTime,
+      'samplingRate=' . $this->samplingRate,
+      'delta=' . $this->delta
+    ));
   }
 
 }

--- a/src/lib/classes/WebService.class.php
+++ b/src/lib/classes/WebService.class.php
@@ -279,21 +279,27 @@ class WebService {
    * @param $time {Number}
    *     default microtime(true).
    *     decimal epoch timestamp.
+   * @param $timeSep {String}
+   *     default 'T'.
+   *     separator between date and time.
+   * @param $utc {String}
+   *     default 'Z'.
+   *     timezone string for UTC.
    * @return {String}
    *     time formatted as ISO8601 with milliseconds.
    */
-  public static function formatISO8601($time=null) {
+  public static function formatISO8601($time=null, $timeSep='\T', $utc='Z') {
     if ($time === null) {
       $time = microtime(true);
     }
 
     $timestr =
         // time without timezone
-        gmdate('Y-m-d\TH:i:s', $time)
+        gmdate('Y-m-d' . $timeSep . 'H:i:s', $time)
         // milliseconds
         . '.' . str_pad(($time * 1000) % 1000, 3, '0', STR_PAD_LEFT)
         // timezone
-        . 'Z';
+        . $utc;
 
     return $timestr;
   }

--- a/src/lib/classes/WebService.class.php
+++ b/src/lib/classes/WebService.class.php
@@ -1,0 +1,270 @@
+<?php
+
+
+/**
+ * Base class for web services.
+ */
+class WebService {
+
+  const ISO8601 = 'Y-m-d\TH:i:s\Z';
+
+  const NO_DATA = 204;
+  const BAD_REQUEST = 400;
+  const NOT_FOUND = 404;
+  const CONFLICT = 409;
+  const SERVER_ERROR = 500;
+  const NOT_IMPLEMENTED = 501;
+  const SERVICE_UNAVAILABLE = 503;
+
+  // status message text
+  public static $statusMessage = array(
+    self::NO_DATA => 'No Data',
+    self::BAD_REQUEST => 'Bad Request',
+    self::NOT_FOUND => 'Not Found',
+    self::CONFLICT => 'Conflict',
+    self::SERVER_ERROR => 'Internal Server Error',
+    self::NOT_IMPLEMENTED => 'Not Implemented',
+    self::SERVICE_UNAVAILABLE => 'Service Unavailable'
+  );
+
+
+  /**
+   * Output a web service error.
+   *
+   * Calls #httpError() or #jsonError() depending on whether
+   *     $_GET['format'] === 'json'.
+   *
+   * @param $code {Number}
+   *     http error code, see class contants.
+   * @param $message {String}
+   *     message describing cause for error.
+   */
+  public function error($code, $message) {
+    global $APP_DIR;
+    // only cache errors for 60 seconds
+    $CACHE_MAXAGE = 60;
+    include $APP_DIR . '/lib/cache.inc.php';
+    if (isset($_GET['format']) && $_GET['format'] === 'json') {
+      // For json requests, user wants json output
+      $this->jsonError($code, $message);
+    } else {
+      $this->httpError($code, $message);
+    }
+  }
+
+  /**
+   * Output json formatted error message.
+   *
+   * @param $code {Number}
+   *     http error code, see class contants.
+   * @param $message {String}
+   *     message describing cause for error.
+   */
+  public function jsonError ($code, $message) {
+    global $HOST_URL_PREFIX;
+    header('Content-type: application/json');
+    // Does this need to look fully like GeoJSON format?
+    $response = array(
+      'type' => 'Error',
+      'metadata' => array(
+        'status' => $code,
+        'generated' => gmdate(self::ISO8601),
+        'url' => $HOST_URL_PREFIX . $_SERVER['REQUEST_URI'],
+        'title' => self::$statusMessage[$code],
+        'api' => self::VERSION,
+        'error' => $message
+      )
+    );
+    echo str_replace('\/', '/', self::safe_json_encode($response));
+    exit();
+  }
+
+  /**
+   * Output plain text error message.
+   *
+   * @param $code {Number}
+   *     http error code, see class contants.
+   * @param $message {String}
+   *     message describing cause for error.
+   */
+  public function httpError ($code, $message) {
+    if (isset(self::$statusMessage[$code])) {
+      $codeMessage = ' ' . self::$statusMessage[$code];
+    } else {
+      $codeMessage = '';
+    }
+    header('HTTP/1.0 ' . $code . $codeMessage);
+    if ($code < 400) {
+      exit();
+    }
+    global $HOST_URL_PREFIX;
+    global $MOUNT_PATH;
+
+    // error message for 400 or 500
+    header('Content-type: text/plain');
+    echo implode("\n", array(
+      'Error ' . $code . ': ' . self::$statusMessage[$code],
+      '',
+      $message,
+      '',
+      'Usage details are available from ' .
+          $HOST_URL_PREFIX . $MOUNT_PATH . '/',
+      '',
+      'Request:',
+      $_SERVER['REQUEST_URI'],
+      '',
+      'Request Submitted:',
+      gmdate(self::ISO8601),
+      '',
+      'Service version:',
+      self::VERSION
+    ));
+    exit();
+  }
+
+
+  /**
+   * Validate a time parameter.
+   *
+   * @param $param parameter name, for error message.
+   * @param $value parameter value
+   * @return value as epoch millisecond timestamp, exit with error if invalid.
+   */
+  protected function validateTime($param, $value) {
+    $parsed = strtotime($value);
+    if ($parsed === false) {
+      $this->error(self::BAD_REQUEST,
+        'Bad ' . $param . ' value "' . $value . '".' .
+        ' Valid values are ISO-8601 timestamps.');
+    }
+    return $parsed;
+  }
+
+  /**
+   * Validate a boolean parameter.
+   *
+   * @param $param parameter name, for error message
+   * @param $value parameter value
+   * @return value as boolean if valid ("true" or "false", case insensitively), exit with error if invalid.
+   */
+  protected function validateBoolean($param, $value) {
+    $val = strtolower($value);
+    if ($val !== 'true' && $val !== 'false') {
+      $this->error(self::BAD_REQUEST,
+          'Bad ' . $param . ' value "' . $value . '".' .
+          ' Valid values are (case insensitive): "TRUE", "FALSE".');
+    }
+    return ($val === 'true');
+  }
+
+  /**
+   * Validate an integer parameter.
+   *
+   * @param $param parameter name, for error message
+   * @param $value parameter value
+   * @param $min minimum valid value for parameter, or null if no minimum.
+   * @param $max maximum valid value for parameter, or null if no maximum.
+   * @return value as integer if valid (integer and in range), exit with error if invalid.
+   */
+  protected function validateInteger($param, $value, $min, $max) {
+    if (
+        !ctype_digit($value)
+        || ($min !== null && intval($value) < $min)
+        || ($max !== null && intval($value) > $max)
+    ) {
+      $message = '';
+      if ($min === null && $max === null) {
+        $message = 'integers';
+      } else {
+        $message = '';
+        if ($min !== null) {
+          $message .= $min . ' <= ';
+        }
+        $message .= $param;
+        if ($max !== null) {
+          $message .= ' <= ' . $max;
+        }
+      }
+      $this->error(self::BAD_REQUEST, 'Bad ' . $param . ' value "' . $value . '".' .
+          ' Valid values are ' . $message);
+    }
+    return intval($value);
+  }
+
+  /**
+   * Validate a float parameter.
+   *
+   * @param $param parameter name, for error message
+   * @param $value parameter value
+   * @param $min minimum valid value for parameter, or null if no minimum.
+   * @param $max maximum valid value for parameter, or null if no maximum.
+   * @return value as float if valid (float and in range), exit with error if invalid.
+   */
+  protected function validateFloat($param, $value, $min, $max) {
+    if (
+        !is_numeric($value)
+        || ($min !== null && floatval($value) < $min)
+        || ($max !== null && floatval($value) > $max)
+    ) {
+      if ($min === null && $max === null) {
+        $message = 'numeric';
+      } else {
+        $message = '';
+        if ($min !== null) {
+          $message .= $min . ' <= ';
+        }
+        $message .= $param;
+        if ($max !== null) {
+          $message .= ' <= ' . $max;
+        }
+      }
+
+      $this->error(self::BAD_REQUEST, 'Bad ' . $param . ' value "' . $value . '".' .
+          ' Valid values are ' . $mesasge);
+    }
+    return floatval($value);
+  }
+
+  /**
+   * Validate a parameter that has an enumerated list of valid values.
+   *
+   * @param $param parameter name, for error message
+   * @param $value parameter value
+   * @param $enum array of valid parameter values.
+   * @return value if valid (in array), exit with error if invalid.
+   */
+  protected function validateEnumerated($param, $value, $enum) {
+    if (!in_array($value, $enum)) {
+      $this->error(self::BAD_REQUEST, 'Bad ' . $param . ' value "' . $value . '".' .
+        ' Valid values are: "' . implode('", "', $enum) . '".');
+    }
+    return $value;
+  }
+
+
+  /**
+   * Safely json_encode values.
+   *
+   * Handles malformed UTF8 characters better than normal json_encode.
+   * from http://stackoverflow.com/questions/10199017/how-to-solve-json-error-utf8-error-in-php-json-decode
+   *
+   * @param $value {Mixed}
+   *        value to encode as json.
+   * @return {String}
+   *         json encoded value.
+   * @throws Exception when unable to json encode.
+   */
+  public static function safe_json_encode($value){
+    $encoded = json_encode($value);
+    $lastError = json_last_error();
+    switch ($lastError) {
+      case JSON_ERROR_NONE:
+        return $encoded;
+      case JSON_ERROR_UTF8:
+        return self::safe_json_encode(self::utf8_encode_array($value));
+      default:
+        throw new Exception('json_encode error (' . $lastError . ')');
+    }
+  }
+
+}

--- a/src/lib/classes/WebService.class.php
+++ b/src/lib/classes/WebService.class.php
@@ -6,8 +6,6 @@
  */
 class WebService {
 
-  const ISO8601 = 'Y-m-d\TH:i:s\Z';
-
   const NO_DATA = 204;
   const BAD_REQUEST = 400;
   const NOT_FOUND = 404;
@@ -26,6 +24,14 @@ class WebService {
     self::NOT_IMPLEMENTED => 'Not Implemented',
     self::SERVICE_UNAVAILABLE => 'Service Unavailable'
   );
+
+
+  public $version;
+
+
+  public function __construct($version = '0.0.0') {
+    $this->version = $version;
+  }
 
 
   /**
@@ -68,10 +74,10 @@ class WebService {
       'type' => 'Error',
       'metadata' => array(
         'status' => $code,
-        'generated' => gmdate(self::ISO8601),
+        'generated' => self::formatISO8601(),
         'url' => $HOST_URL_PREFIX . $_SERVER['REQUEST_URI'],
         'title' => self::$statusMessage[$code],
-        'api' => self::VERSION,
+        'api' => $this->version,
         'error' => $message
       )
     );
@@ -114,10 +120,10 @@ class WebService {
       $_SERVER['REQUEST_URI'],
       '',
       'Request Submitted:',
-      gmdate(self::ISO8601),
+      self::formatISO8601(),
       '',
       'Service version:',
-      self::VERSION
+      $this->version
     ));
     exit();
   }
@@ -265,6 +271,31 @@ class WebService {
       default:
         throw new Exception('json_encode error (' . $lastError . ')');
     }
+  }
+
+  /**
+   * Format a epoch timestamp as ISO8601 with milliseconds.
+   *
+   * @param $time {Number}
+   *     default microtime(true).
+   *     decimal epoch timestamp.
+   * @return {String}
+   *     time formatted as ISO8601 with milliseconds.
+   */
+  public static function formatISO8601($time=null) {
+    if ($time === null) {
+      $time = microtime(true);
+    }
+
+    $timestr =
+        // time without timezone
+        gmdate('Y-m-d\TH:i:s', $time)
+        // milliseconds
+        . '.' . str_pad(($time * 1000) % 1000, 3, '0', STR_PAD_LEFT)
+        // timezone
+        . 'Z';
+
+    return $timestr;
   }
 
 }


### PR DESCRIPTION
The initial implementation made several (incorrect) assumptions about times for data stored in EDGE.  ObsRIO samples are not actually reported on the second or minute, and vary channel to channel; but the time handling code masked that problem.

This change updates time handling to:
- use sample times as reported by edge
- generate errors when multiple channels report incompatible times
- align generated gaps to existing times


Example CMT request:
http://geomag.usgs.gov/ws/edge/?id=CMT&elements=MVH,MVE,MVZ,MVF

Before:
[existing_output.iaga.txt](https://github.com/usgs/geomag-edge-ws/files/390924/existing_output.iaga.txt)
```
DATE       TIME         DOY     CMTMVH    CMTMVE    CMTMVZ    CMTMVF |
2016-07-29 00:00:00.000 211     12412.04   -188.18  55365.38  56739.93
2016-07-29 00:01:00.000 211     12408.85   -182.26  55366.94  56740.74
2016-07-29 00:02:00.000 211     12409.55   -176.87  55370.26  56744.11
2016-07-29 00:03:00.000 211     12411.88   -177.99  55372.05  56746.36
2016-07-29 00:04:00.000 211     12413.25   -180.28  55372.61  56747.23
```

After, note that times were previously misreported by almost 22 seconds:
[pullrequest_output.iaga.txt](https://github.com/usgs/geomag-edge-ws/files/390925/pullrequest_output.iaga.txt)
```
DATE       TIME         DOY     CMTMVH    CMTMVE    CMTMVZ    CMTMVF |
2016-07-29 00:00:39.019 211     12408.85   -182.26  55366.94  56740.74
2016-07-29 00:01:39.019 211     12409.55   -176.87  55370.26  56744.11
2016-07-29 00:02:39.019 211     12411.88   -177.99  55372.05  56746.36
2016-07-29 00:03:39.019 211     12413.25   -180.28  55372.61  56747.23
2016-07-29 00:04:39.019 211     12413.66   -181.24  55372.29  56747.00
```