### PR TITLE
Update empty values output by Iaga2002OutputFormat

### DIFF
--- a/src/lib/classes/Iaga2002OutputFormat.class.php
+++ b/src/lib/classes/Iaga2002OutputFormat.class.php
@@ -3,7 +3,8 @@
 class Iaga2002OutputFormat {
 
   static $EMPTY_CHANNEL = 'NUL';
-  static $EMPTY_VALUE = '99999.99';
+  static $EMPTY_CHANNEL_VALUE = '88888.00';
+  static $EMPTY_VALUE = '99999.00';
 
 
   public function output($data, $query, $metadata) {
@@ -113,7 +114,7 @@ class Iaga2002OutputFormat {
         $values[] = $value;
       }
       while (count($values) < 4) {
-        $values[] = self::$EMPTY_VALUE;
+        $values[] = self::$EMPTY_CHANNEL_VALUE;
       }
       $buf .= $this->formatValues($times[$i], $values);
     }


### PR DESCRIPTION
Missing data should be `99999` with zeroes after the decimal.
Non-observed data should be `88888` with zeros after the decimal.