### PR TITLE
Update gapEnd to be time of last missing sample

### DIFF
--- a/src/lib/classes/Timeseries.class.php
+++ b/src/lib/classes/Timeseries.class.php
@@ -159,10 +159,11 @@ class Timeseries {
     $i = 0;
     $time = $startTime;
     foreach ($gaps as $gap) {
+
       // time of first missing sample
       $gapStart = $gap[0] + $delta;
-      // time of next sample
-      $gapEnd = $gap[1];
+      // time of last missing sample
+      $gapEnd = $gap[1] - $delta;
 
       // copy actual data before gap
       while ($i < $size && $this->times[$i] < $gapStart) {
@@ -185,6 +186,7 @@ class Timeseries {
         $timeseries->times[] = $time;
         $g = $g + 1;
       }
+
     }
 
     // copy remaining actual data

--- a/src/lib/classes/Timeseries.class.php
+++ b/src/lib/classes/Timeseries.class.php
@@ -118,7 +118,7 @@ class Timeseries {
     }
 
     // copy data in range
-    while ($i < $size && $time < $endTime) {
+    while ($i < $size && $this->times[$i] <= $endTime) {
       $time = $this->times[$i];
       $timeseries->data[] = $this->data[$i];
       $timeseries->times[] = $time;


### PR DESCRIPTION
fillGaps was previously inserting an extra gap value with the same time, just before the first data value (leading to duplication of the time following the actual gap).  This was unnoticed in the plots interface because only one channel at a time is requested.