### PR TITLE
Correct Fluxgate and Total Field Temperature labels

### DIFF
--- a/src/htdocs/elements.json
+++ b/src/htdocs/elements.json
@@ -139,7 +139,7 @@
     },
     {
       "type": "Feature",
-      "id": "UK2",
+      "id": "UK3",
       "properties": {
         "abbreviation": "T-Fluxgate",
         "name": "Fluxgate Temperature",
@@ -149,7 +149,7 @@
     },
     {
       "type": "Feature",
-      "id": "UK3",
+      "id": "UK2",
       "properties": {
         "abbreviation": "T-Total Field",
         "name": "Total Field Temperature",


### PR DESCRIPTION
Reversed labels for UK2 and UK3; Total Field Temp and Fluxgate Temp.


Specifically: order of plots was correct, but labels on plots were incorrect.