### PR TITLE
E-E/E-N for Electric Field Data Request

### DIFF
--- a/src/htdocs/index.php
+++ b/src/htdocs/index.php
@@ -46,6 +46,15 @@ if (!isset($TEMPLATE)) {
   echo '<a href="' . $url . '">' . $url . '</a>';
 ?>
   </dd>
+
+  <dt>BOU electric field data for current UTC day in IAGA2002 format</dt>
+  <dd>
+<?php
+  $url = $HOST_URL_PREFIX . $MOUNT_PATH . '/?id=BOU&elements=E-N,E-E';
+  echo '<a href="' . $url . '">' . $url . '</a>';
+?>
+  </dd>
+
 </dl>
 
 
@@ -115,6 +124,13 @@ if (!isset($TEMPLATE)) {
   <dd>
     Comma separated list of requested elements.<br/>
     Default: <code>X,Y,Z,F</code><br/>
+    Valid values:
+      <code>X</code>,
+      <code>Y</code>,
+      <code>Z</code>,
+      <code>F</code>,
+      <code>E-N</code>,
+      <code>E-E</code>
   </dd>
 
   <dt>sampling_period</dt>

--- a/src/htdocs/index.php
+++ b/src/htdocs/index.php
@@ -7,6 +7,8 @@ include_once $LIB_DIR . '/classes/GeomagWebService.class.php';
 
 if (!isset($TEMPLATE)) {
   // any parameters
+  $validElements = array('E-E','E-N','D','E','H','F','G','SQ','SV','DIST','DST','UK1','UK2','UK3','UK4','X','Y','Z');
+  sort($validElements);
   $metadata = array();
   $json = json_decode(file_get_contents('observatories.json'), true);
   foreach ($json['features'] as $obs) {
@@ -125,12 +127,11 @@ if (!isset($TEMPLATE)) {
     Comma separated list of requested elements.<br/>
     Default: <code>X,Y,Z,F</code><br/>
     Valid values:
-      <code>X</code>,
-      <code>Y</code>,
-      <code>Z</code>,
-      <code>F</code>,
-      <code>E-N</code>,
-      <code>E-E</code>
+    <?php
+            echo '<code>' .
+                implode('</code>, <code>', array_values($validElements)) .
+                '</code>';
+    ?>
   </dd>
 
   <dt>sampling_period</dt>

--- a/src/htdocs/index.php
+++ b/src/htdocs/index.php
@@ -7,8 +7,25 @@ include_once $LIB_DIR . '/classes/GeomagWebService.class.php';
 
 if (!isset($TEMPLATE)) {
   // any parameters
-  $validElements = array('E-E','E-N','D','E','H','F','G','SQ','SV','DIST','DST','UK1','UK2','UK3','UK4','X','Y','Z');
-  sort($validElements);
+  $validElements = array(
+      'D',
+      'DIST',
+      'DST',
+      'E',
+      'E-E',
+      'E-N',
+      'F',
+      'G',
+      'H',
+      'SQ',
+      'SV',
+      'UK1',
+      'UK2',
+      'UK3',
+      'UK4',
+      'X',
+      'Y',
+      'Z');
   $metadata = array();
   $json = json_decode(file_get_contents('observatories.json'), true);
   foreach ($json['features'] as $obs) {
@@ -127,11 +144,11 @@ if (!isset($TEMPLATE)) {
     Comma separated list of requested elements.<br/>
     Default: <code>X,Y,Z,F</code><br/>
     Valid values:
-    <?php
-            echo '<code>' .
-                implode('</code>, <code>', array_values($validElements)) .
-                '</code>';
-    ?>
+<?php
+        echo '<code>' .
+            implode('</code>, <code>', array_values($validElements)) .
+            '</code>';
+?>
   </dd>
 
   <dt>sampling_period</dt>

--- a/src/lib/classes/GeomagWebService.class.php
+++ b/src/lib/classes/GeomagWebService.class.php
@@ -48,10 +48,6 @@ class GeomagWebService extends WebService {
       // streaming supports more samples
       // 345600 = 4 elements * 24 hours * 3600 samples/hour
       // 44640 = 31 days * 24 hours/day * 60 samples/hour
-      if (count($query->elements) > 4){
-        $this->error(self::BAD_REQUEST,
-            'IAGA2002 format is limited to 4 elements per request');
-      }
       if ($requested_samples > 345600) {
         $this->error(self::BAD_REQUEST,
             'IAGA2002 format is limited to 345600 samples per request');
@@ -211,9 +207,11 @@ class GeomagWebService extends WebService {
 
     $element = strtoupper($element);
     switch ($element) {
-      case 'E-N':
       case 'E-E':
-        $channel = $prefix . 'Q' . substr(element, -1);
+        $channel = $prefix . 'QE';
+        break;
+      case 'E-N':
+        $channel = $prefix . 'QN';
         break;
       case 'D':
       case 'E':
@@ -328,6 +326,10 @@ class GeomagWebService extends WebService {
     if ($query->elements === null) {
       // default when not specified
       $query->elements = array('X', 'Y', 'Z', 'F');
+    }
+    //
+    if (count($query->elements) > 4 && $query->format === 'iaga2002'){
+      throw new Exception('IAGA2002 format is limited to 4 elements per request');
     }
 
     return $query;

--- a/src/lib/classes/GeomagWebService.class.php
+++ b/src/lib/classes/GeomagWebService.class.php
@@ -48,6 +48,10 @@ class GeomagWebService extends WebService {
       // streaming supports more samples
       // 345600 = 4 elements * 24 hours * 3600 samples/hour
       // 44640 = 31 days * 24 hours/day * 60 samples/hour
+      if (count($query->elements) > 4){
+        $this->error(self::BAD_REQUEST,
+            'IAGA2002 format is limited to 4 elements per request');
+      }
       if ($requested_samples > 345600) {
         $this->error(self::BAD_REQUEST,
             'IAGA2002 format is limited to 345600 samples per request');

--- a/src/lib/classes/GeomagWebService.class.php
+++ b/src/lib/classes/GeomagWebService.class.php
@@ -207,6 +207,10 @@ class GeomagWebService extends WebService {
 
     $element = strtoupper($element);
     switch ($element) {
+      case 'E-N':
+      case 'E-E':
+        $channel = $prefix . 'Q' . substr(element, -1);
+        break;
       case 'D':
       case 'E':
       case 'H':

--- a/src/lib/classes/Iaga2002OutputFormat.class.php
+++ b/src/lib/classes/Iaga2002OutputFormat.class.php
@@ -126,8 +126,6 @@ class Iaga2002OutputFormat {
     }
     $r = '';
     foreach ($channels as $channel) {
-      if ($channel === 'MQN' or $channel === 'SQN') $channel = 'E-N';
-      if ($channel === 'MQE' or $channel === 'SQE') $channel = 'E-E';
       $r .= '   ' . str_pad($station . $channel, 7);
     }
     return $prefix . $r . $suffix;

--- a/src/lib/classes/Iaga2002OutputFormat.class.php
+++ b/src/lib/classes/Iaga2002OutputFormat.class.php
@@ -128,7 +128,6 @@ class Iaga2002OutputFormat {
     foreach ($channels as $channel) {
       if ($channel === 'MQN' or $channel === 'SQN') $channel = 'E-N';
       if ($channel === 'MQE' or $channel === 'SQE') $channel = 'E-E';
-      if ($count++ > 3) break;
       $r .= '   ' . str_pad($station . $channel, 7);
     }
     return $prefix . $r . $suffix;

--- a/src/lib/classes/Iaga2002OutputFormat.class.php
+++ b/src/lib/classes/Iaga2002OutputFormat.class.php
@@ -126,6 +126,9 @@ class Iaga2002OutputFormat {
     }
     $r = '';
     foreach ($channels as $channel) {
+      if ($channel === 'MQN' or $channel === 'SQN') $channel = 'E-N';
+      if ($channel === 'MQE' or $channel === 'SQE') $channel = 'E-E';
+      if ($count++ > 3) break;
       $r .= '   ' . str_pad($station . $channel, 7);
     }
     return $prefix . $r . $suffix;


### PR DESCRIPTION
If E-E or E-N are used as elements in the search bar, they will be accepted in place of MQE/MQN/SQE/SQN depending on the sampling period.