### PR TITLE
First sample missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geomag-edge-ws",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "description": "Geomag timeseries web service",
   "main": "Gruntfile.js",
   "repository": {

--- a/src/lib/classes/Timeseries.class.php
+++ b/src/lib/classes/Timeseries.class.php
@@ -100,13 +100,12 @@ class Timeseries {
 
     $delta = ($delta == null ? $this->estimateDelta() : $delta);
 
-    $time = $this->times[0];
-    $i = 1;
-
     // ignore data before start
-    while ($i < $size && $time < $startTime) {
+    for ($i = 0; $i < $size; $i++) {
       $time = $this->times[$i];
-      $i = $i + 1;
+      if ($time >= $startTime) {
+        break;
+      }
     }
 
     // leading gap, will be filled by fillGaps


### PR DESCRIPTION
Setting $i to 1 prevented a notice, but also skipped the first requested sample.