### PR TITLE
Reduce web service caching to 5 minutes (from default of 1 day)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geomag-edge-ws",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Geomag timeseries web service",
   "main": "Gruntfile.js",
   "repository": {

--- a/src/lib/classes/GeomagWebService.class.php
+++ b/src/lib/classes/GeomagWebService.class.php
@@ -65,6 +65,11 @@ class GeomagWebService extends WebService {
       // so errors connecting can be caught before any output
       $this->waveserver->connect();
 
+      // only cache for 5 minutes
+      global $APP_DIR;
+      $CACHE_MAXAGE = 300;
+      include $APP_DIR . '/lib/cache.inc.php';
+
       if ($query->format === 'iaga2002') {
         $output = new Iaga2002OutputFormat();
         $output->run($this, $query, $this->metadata);


### PR DESCRIPTION
Default caching header from apache is 1 day.
Set 5 minute caching interval for web service responses.