### PR TITLE
Update units for delta f channel

### DIFF
--- a/src/htdocs/elements.json
+++ b/src/htdocs/elements.json
@@ -22,6 +22,24 @@
     },
     {
       "type": "Feature",
+      "id": "X",
+      "properties": {
+        "name": "Geographic North Magnitude",
+        "units": "nT"
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
+      "id": "Y",
+      "properties": {
+        "name": "Geographic East Magnitude",
+        "units": "nT"
+      },
+      "geometry": null
+    },
+    {
+      "type": "Feature",
       "id": "D",
       "properties": {
         "name": "Declination (deci-arcminute)",
@@ -53,29 +71,10 @@
       "properties": {
         "abbreviation": "ΔF",
         "name": "Delta F",
-        "units": "nT"
+        "units": "ΔnT"
       },
       "geometry": null
     },
-    {
-      "type": "Feature",
-      "id": "X",
-      "properties": {
-        "name": "Geographic North Magnitude",
-        "units": "nT"
-      },
-      "geometry": null
-    },
-    {
-      "type": "Feature",
-      "id": "Y",
-      "properties": {
-        "name": "Geographic East Magnitude",
-        "units": "nT"
-      },
-      "geometry": null
-    },
-
 
     {
       "type": "Feature",


### PR DESCRIPTION
This will treat delta-f as a separate auto scale unit, while making it clear that it is still reported in nT units.

Also move X,Y channels before Z,F for better ordering in plots.