### PR TITLE
Use strict null check

### DIFF
--- a/src/lib/classes/GeomagWebService.class.php
+++ b/src/lib/classes/GeomagWebService.class.php
@@ -158,7 +158,7 @@ class GeomagWebService extends WebService {
 
       // scale values
       $data[$element]['values'] = array_map(function ($v) {
-        return ($v == null ? null : $v / 1000);
+        return ($v === null ? null : $v / 1000);
       }, $timeseries->data);
     }
 


### PR DESCRIPTION
Zero values were converted to gaps because of this check.